### PR TITLE
Adding Specific Response Headers to CSV output

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const CSV = {
  * @param {Object} options - A set of collection run options.
  * @param {String} options.export - The path to which the summary object must be written.
  * @param {String} options.includeBody - Whether the response body should be included in each row.
- * @param {Array<String>} options.includeResponseHeaders - 
+ * @param {Array<String>} options.includeResponseHeaders - List of response headers to be included in each row.
  * @returns {*}
  */
 module.exports = function newmanCSVReporter(newman, options) {

--- a/index.js
+++ b/index.js
@@ -28,15 +28,15 @@ const CSV = {
  * @param {Object} options - A set of collection run options.
  * @param {String} options.export - The path to which the summary object must be written.
  * @param {String} options.includeBody - Whether the response body should be included in each row.
- * @param {Array<String>} options.includeResponseHeaders - 
+ * @param {Array<String>} options.includeResponseHeaders -
  * @returns {*}
  */
-module.exports = function newmanCSVReporter(newman, options) {
+module.exports = function newmanCSVReporter (newman, options) {
   if (options.includeBody) {
     columns.push('body')
   }
   if (options.includeResponseHeaders) {
-    options.includeResponseHeaders.split(",").forEach(v => columns.push(v));
+    options.includeResponseHeaders.split(',').forEach(v => columns.push(v))
   }
 
   newman.on('beforeItem', (err, e) => {
@@ -66,19 +66,18 @@ module.exports = function newmanCSVReporter(newman, options) {
     if (options.includeBody) {
       Object.assign(log, { body: stream.toString() })
     }
-    let headers = {};
+    const headers = {}
     const parsedResponse = JSON.parse(JSON.stringify(e.response))
     if (parsedResponse.header) {
-      parsedResponse.header.reduce((previous, current) => { previous[current.key] = current.value; return previous; }, headers);
+      parsedResponse.header.reduce((previous, current) => { previous[current.key] = current.value; return previous }, headers)
     }
 
     if (options.includeResponseHeaders) {
-      options.includeResponseHeaders.split(",").forEach(v => {
-        let obj = {}; obj[v] = headers[v];
+      options.includeResponseHeaders.split(',').forEach(v => {
+        const obj = {}; obj[v] = headers[v]
         Object.assign(log, obj)
-      });
+      })
     }
-
   })
 
   newman.on('assertion', (err, e) => {
@@ -109,7 +108,7 @@ module.exports = function newmanCSVReporter(newman, options) {
   })
 }
 
-function getResults() {
+function getResults () {
   const results = logs.map((log) => {
     const row = []
 


### PR DESCRIPTION
The idea of this change is to allow specific response headers to be added on each row of the CSV output. 