### PR TITLE
commented console log csv write complete to clear logging

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function newmanCSVReporter (newman, options) {
       content: getResults()
     })
 
-    console.log('CSV write complete!')
+    //console.log('CSV write complete!')
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ module.exports = function newmanCSVReporter (newman, options) {
       content: getResults()
     })
 
-    //console.log('CSV write complete!')
+    //  console.log('CSV write complete!')
   })
 }
 


### PR DESCRIPTION
commented console log csv write complete to clear unnecessary console logging. Have implemented newman-reporter-csv for AWS lambda function and console logs are logged on cloudwatch . I think logging "csv write complete" could be avoided.