### PR TITLE
Add count columns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 node_modules
+
+./newman

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 
+# For development
 newman

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules
 
-./newman
+newman

--- a/README.md
+++ b/README.md
@@ -17,11 +17,14 @@ Each request in a collection run maps to a row in the outputted CSV file with th
 | code | response code of the request | 200 |
 | responseTime | time taken to receive a response (ms) | 56 |
 | responseSize | size of the response (bytes) | 130 |
-| executed | tests that passed | Status was 200, User was created |
-| failed | tests that failed | User has view permissions |
-| skipped | tests that were skipped | User had first name Joe |
-| body | the response body | { foo: "bar" } |
-> *Note: test names are comma separated | `body` is optional, see [Options](#options)*
+| executed | test names that passed *(comma separated)* | Status was 200, User was created |
+| failed | test names that failed *(comma separated)* | User has view permissions |
+| skipped | test names that were skipped *(comma separated)* | User had first name Joe |
+| body | the response body *(optional column. see [Options](#options))* | { foo: "bar" } |
+| totalAssertions | Total number of test assertions on the request | 4 |
+| passedCount | Total number of test assertions that passed | 2 |
+| failedCount | Total number of test assertions that failed | 1 |
+| skippedCount | Total number of test assertions that were skipped | 1 |
 
 ## Setup
 Ensure you have Newman setup first:

--- a/index.js
+++ b/index.js
@@ -19,7 +19,6 @@ const columns = [
   'skippedCount'
 ]
 
-
 const CSV = {
   stringify: (str) => {
     return `"${str.replace(/"/g, '""')}"`

--- a/index.js
+++ b/index.js
@@ -10,10 +10,15 @@ const columns = [
   'code',
   'responseTime',
   'responseSize',
+  'totalAssertions',
+  'executedCount',
+  'failedCount',
+  'skippedCount',
   'executed',
   'failed',
   'skipped'
 ]
+
 
 const CSV = {
   stringify: (str) => {
@@ -50,7 +55,11 @@ module.exports = function newmanCSVReporter (newman, options) {
       iteration: cursor.iteration + 1,
       requestName: item.name,
       method: request.method,
-      url: request.url.toString()
+      url: request.url.toString(),
+      totalAssertions: 0,
+      executedCount: 0,
+      failedCount: 0,
+      skippedCount: 0,
     })
   })
 
@@ -70,6 +79,11 @@ module.exports = function newmanCSVReporter (newman, options) {
 
     log[key] = log[key] || []
     log[key].push(assertion)
+
+    log['totalAssertions']++
+    const assertionKey = (key == 'executed') ? 'executedCount' :
+                        (key == 'skipped') ? 'skippedCount' : 'failedCount'
+    log[assertionKey]++
   })
 
   newman.on('item', (err, e) => {

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ const columns = [
   'failed',
   'skipped',
   'totalAssertions',
-  'passedCount',
+  'executedCount',
   'failedCount',
-  'skippedCount',
+  'skippedCount'
 ]
 
 
@@ -57,9 +57,9 @@ module.exports = function newmanCSVReporter (newman, options) {
       method: request.method,
       url: request.url.toString(),
       totalAssertions: 0,
-      passedCount: 0,
+      executedCount: 0,
       failedCount: 0,
-      skippedCount: 0,
+      skippedCount: 0
     })
   })
 
@@ -81,9 +81,7 @@ module.exports = function newmanCSVReporter (newman, options) {
     log[key].push(assertion)
 
     log['totalAssertions']++
-    const assertionKey = (key == 'executed') ? 'passedCount' :
-                        (key == 'skipped') ? 'skippedCount' : 'failedCount'
-    log[assertionKey]++
+    log[`${key}Count`]++
   })
 
   newman.on('item', (err, e) => {

--- a/index.js
+++ b/index.js
@@ -80,7 +80,7 @@ module.exports = function newmanCSVReporter (newman, options) {
     log[key] = log[key] || []
     log[key].push(assertion)
 
-    log['totalAssertions']++
+    log.totalAssertions++
     log[`${key}Count`]++
   })
 

--- a/index.js
+++ b/index.js
@@ -10,13 +10,13 @@ const columns = [
   'code',
   'responseTime',
   'responseSize',
-  'totalAssertions',
-  'executedCount',
-  'failedCount',
-  'skippedCount',
   'executed',
   'failed',
-  'skipped'
+  'skipped',
+  'totalAssertions',
+  'passedCount',
+  'failedCount',
+  'skippedCount',
 ]
 
 
@@ -57,7 +57,7 @@ module.exports = function newmanCSVReporter (newman, options) {
       method: request.method,
       url: request.url.toString(),
       totalAssertions: 0,
-      executedCount: 0,
+      passedCount: 0,
       failedCount: 0,
       skippedCount: 0,
     })
@@ -81,7 +81,7 @@ module.exports = function newmanCSVReporter (newman, options) {
     log[key].push(assertion)
 
     log['totalAssertions']++
-    const assertionKey = (key == 'executed') ? 'executedCount' :
+    const assertionKey = (key == 'executed') ? 'passedCount' :
                         (key == 'skipped') ? 'skippedCount' : 'failedCount'
     log[assertionKey]++
   })


### PR DESCRIPTION
This pull request addresses the feature request #15 and adds the following columns to the generated csv:

- `totalAssertions` (which should be a sum of the next 3 columns)
- `executedCount`
- `failedCount`
- `skippedCount`

----

Personally, I would have put the tally columns before the description columns for ease of human readability.  However, for backwards compatibility (aka people parsing the csv without cross-referencing the column headers), I put them at the end.  If this is not a concern, I will happily reverse the order.

----
I tested doing a full `npm install` on node v16.13.2